### PR TITLE
Net Client/Server clean up.

### DIFF
--- a/src/main/scala/org/vertx/scala/core/net/NetClient.scala
+++ b/src/main/scala/org/vertx/scala/core/net/NetClient.scala
@@ -25,7 +25,9 @@ import org.vertx.java.core.impl.DefaultFutureResult
 
 /**
  *
- * @author swilliams, Edgar Chan, Ranie Jade Ramiso
+ * @author swilliams
+ * @author Edgar Chan
+ * @author Ranie Jade Ramiso
  *
  */
 object NetClient {

--- a/src/main/scala/org/vertx/scala/core/net/NetServer.scala
+++ b/src/main/scala/org/vertx/scala/core/net/NetServer.scala
@@ -22,7 +22,9 @@ import org.vertx.java.core.{Handler, AsyncResult, ServerTCPSupport, ServerSSLSup
 import org.vertx.java.core.impl.DefaultFutureResult
 
 /**
- * @author swilliams, Ranie Jade Ramiso
+ *
+ * @author swilliams
+ * @author Ranie Jade Ramiso
  *
  */
 object NetServer {


### PR DESCRIPTION
Removed explicit return types and redundant braces on property accessors.
