### PR TITLE
Bugfix: ClassCastException if configuration is provided

### DIFF
--- a/src/main/scala/org/vertx/scala/core/json/JSON.scala
+++ b/src/main/scala/org/vertx/scala/core/json/JSON.scala
@@ -20,7 +20,6 @@ import scala.util.parsing.json.JSONObject
 import scala.util.parsing.json.JSONArray
 import org.vertx.java.core.json.JsonObject
 import org.vertx.java.core.json.JsonArray
-import scala.util.parsing.json.{ JSON => sJSON }
 import scala.collection.JavaConversions._
 import org.vertx.java.core.json.DecodeException
 


### PR DESCRIPTION
scala.util.parsing.JSON.parseRaw() returns an Option[JSONType] - None if it could not decode it or Some(x) if it could. x may also be of another type (like JSONArray), so the code now throws a DecodeException if it wasn't decodeable.
