### PR TITLE
Changed 'new*' methods to 'create*' for more consistency to the Java API

### DIFF
--- a/src/main/scala/org/vertx/scala/core/package.scala
+++ b/src/main/scala/org/vertx/scala/core/package.scala
@@ -49,20 +49,20 @@ package object core {
 
     def cancelTimer(id: Long):Boolean = internal.cancelTimer(id)
 
-    def newHttpServer:HttpServer = HttpServer(internal.createHttpServer)
+    def createHttpServer:HttpServer = HttpServer(internal.createHttpServer)
 
-    def newHttpServer(h: HttpServerRequest => Unit):HttpServer =
+    def createHttpServer(h: HttpServerRequest => Unit):HttpServer =
          HttpServer(internal.createHttpServer).requestHandler(h)
 
-    def newHttpClient:HttpClient = HttpClient(internal.createHttpClient)
+    def createHttpClient:HttpClient = HttpClient(internal.createHttpClient)
 
-    def newNetClient:NetClient = NetClient(internal.createNetClient)
+    def createNetClient:NetClient = NetClient(internal.createNetClient)
 
-    def newNetServer:NetServer = NetServer(internal.createNetServer)
+    def createNetServer:NetServer = NetServer(internal.createNetServer)
 
-    def newSockJSServer(httpServer: HttpServer):SockJSServer = SockJSServer(internal.createSockJSServer(httpServer.actual))
+    def createSockJSServer(httpServer: HttpServer):SockJSServer = SockJSServer(internal.createSockJSServer(httpServer.actual))
 
-    def newFileSystem:FileSystem = FileSystem(internal.fileSystem)
+    def fileSystem:FileSystem = FileSystem(internal.fileSystem)
 
     def isEventLoop:Boolean = internal.isEventLoop
 

--- a/src/test/scala/org/vertx/scala/examples/file/SimpleFileReaderVerticle.scala
+++ b/src/test/scala/org/vertx/scala/examples/file/SimpleFileReaderVerticle.scala
@@ -11,7 +11,7 @@ class SimpleFileReaderVerticle extends Verticle {
   override def start(future: Future[Void]) {
     val fileName = "afile.txt"
 
-    vertx.newFileSystem.readFile(fileName, { ar =>
+    vertx.fileSystem.readFile(fileName, { ar =>
         if (ar.succeeded()) {
           val fileContentsAsString = ar.result().toString()
         }

--- a/src/test/scala/org/vertx/scala/examples/http/SimpleHelloWorldHttpVerticle.scala
+++ b/src/test/scala/org/vertx/scala/examples/http/SimpleHelloWorldHttpVerticle.scala
@@ -26,7 +26,7 @@ class SimpleHelloWorldHttpVerticle extends Verticle {
 
   override def start(future: Future[Void]):Unit = {
     start()
-    vertx.newHttpServer.requestHandler { req: HttpServerRequest =>
+    vertx.createHttpServer.requestHandler { req: HttpServerRequest =>
       req.response.end("Hello World!")
 
     }.listen(8080, { ar =>

--- a/src/test/scala/org/vertx/scala/examples/http/SimpleSendFileHttpVerticle.scala
+++ b/src/test/scala/org/vertx/scala/examples/http/SimpleSendFileHttpVerticle.scala
@@ -26,7 +26,7 @@ class SimpleSendFileHttpVerticle extends Verticle {
 
   override def start(future: Future[Void]):Unit = {
     start()
-    vertx.newHttpServer.requestHandler { req: HttpServerRequest =>
+    vertx.createHttpServer.requestHandler { req: HttpServerRequest =>
       val file: String = if (req.path == "/") "index.html" else req.path
       req.response.sendFile(file, "404.html")
 

--- a/src/test/scala/org/vertx/scala/tests/FileSystemTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/FileSystemTest.scala
@@ -32,6 +32,7 @@ class FileSystemTest extends TestVerticle {
 
   import org.vertx.scala.core._
 
+  lazy val sVertx = Vertx(getVertx)
   lazy val fileDir =  System.getProperty("java.io.tmpdir") + "/vertx"
   lazy val path = FileSystems.getDefault.getPath(fileDir)
 
@@ -44,7 +45,7 @@ class FileSystemTest extends TestVerticle {
 
   @Test
   def copyTest(){
-    val fs = vertx.newFileSystem
+    val fs = sVertx.fileSystem
     val from = fileDir + "/foo.tmp"
     val to = fileDir + "/bar.tmp"
     val content = "some-data"
@@ -63,7 +64,7 @@ class FileSystemTest extends TestVerticle {
 
   @Test
   def moveTest(){
-    val fs = vertx.newFileSystem
+    val fs = sVertx.fileSystem
     val from = fileDir + "/foo1.tmp"
     val to = fileDir + "/bar2.tmp"
     val content = "some-data"
@@ -86,7 +87,7 @@ class FileSystemTest extends TestVerticle {
 
   @Test
   def readDirTest(){
-    val fs = vertx.newFileSystem
+    val fs = sVertx.fileSystem
     val f1 = fileDir + "/foo.tmp"
     val f2 = fileDir + "/bar.tmp"
     val f3 = fileDir + "/baz.tmp"
@@ -108,7 +109,7 @@ class FileSystemTest extends TestVerticle {
 
   @Test
   def propTest(){
-    val fs = vertx.newFileSystem
+    val fs = sVertx.fileSystem
     val f1 = fileDir + "/baz.tmp"
     val content = "some-data"
     fs.writeFile(f1, content, () => {
@@ -122,7 +123,7 @@ class FileSystemTest extends TestVerticle {
 
   @Test
   def pumpFileTest(){
-    val fs = vertx.newFileSystem
+    val fs = sVertx.fileSystem
     val from = fileDir + "/foo.tmp"
     val to = fileDir + "/bar.tmp"
     val content = TestUtils.generateRandomBuffer(10000)

--- a/src/test/scala/org/vertx/scala/tests/NetServerTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/NetServerTest.scala
@@ -32,6 +32,8 @@ class NetServerTest extends TestVerticle{
   import org.vertx.scala.core._
   import org.vertx.scala.core.buffer.Buffer._
 
+  lazy val sVertx = Vertx(getVertx)
+
   @Test
   def echoNoSSLTest(){
     echoTest(withSSl = false)
@@ -44,8 +46,8 @@ class NetServerTest extends TestVerticle{
 
   private def echoTest(withSSl:Boolean){
 
-    val server = vertx.newNetServer
-    val client = vertx.newNetClient
+    val server = sVertx.createNetServer
+    val client = sVertx.createNetClient
 
 
     if (withSSl){

--- a/src/test/scala/org/vertx/scala/tests/http/ScalaHttpTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/http/ScalaHttpTest.scala
@@ -32,17 +32,19 @@ class ScalaHttpTest extends TestVerticle{
 
   import org.vertx.scala.core._
 
+  lazy val sVertx = Vertx(getVertx)
+
   @Test
   def testClientDefaults() {
 
     val html = "<html><body><h1>Hello from vert.x!</h1></body></html>"
     val port = 8080
 
-    vertx.newHttpServer{
+    sVertx.createHttpServer{
       r => r.response.end(html, "utf8")
     }.listen(port, { ar: AsyncResult[HttpServer] =>
         assertTrue(ar.succeeded())
-        val client = vertx.newHttpClient.setPort(port)
+        val client = sVertx.createHttpClient.setPort(port)
         client.getNow("/"){
           h => h.bodyHandler {
                   data => {
@@ -57,7 +59,7 @@ class ScalaHttpTest extends TestVerticle{
 
   @Test
   def testListenInvalidPort() {
-    val server = vertx.newHttpServer
+    val server = sVertx.createHttpServer
 
     server.requestHandler{ r =>   }
 
@@ -71,7 +73,7 @@ class ScalaHttpTest extends TestVerticle{
 
   @Test
   def testListenInvalidHost() {
-    val server = vertx.newHttpServer;
+    val server = sVertx.createHttpServer;
     server.requestHandler { r => }
 
     server.listen(80, "iqwjdoqiwjdoiqwdiojwd", {

--- a/src/test/scala/org/vertx/scala/tests/http/ScalaWebSocketTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/http/ScalaWebSocketTest.scala
@@ -7,6 +7,7 @@ import org.vertx.java.core.buffer.Buffer
 import org.vertx.java.core.AsyncResult
 import org.vertx.java.core.http.HttpServer
 import org.vertx.testtools.VertxAssert._
+import org.vertx.scala.core.Vertx
 
 /**
  * Web socket Scala facade test.
@@ -17,15 +18,17 @@ class ScalaWebSocketTest extends TestVerticle {
 
   import org.vertx.scala.core._
 
+  lazy val sVertx: Vertx = Vertx(getVertx)
+
   @Test
   def testHtmlOverWebSocket() {
     val html = <html><body><h1>Hello from Vert.x Scala Websocket!</h1></body></html>
     val port = 8080
 
-    vertx.newHttpServer.websocketHandler(_.writeXml(html)).listen(port, {
+    sVertx.createHttpServer.websocketHandler(_.writeXml(html)).listen(port, {
       ar: AsyncResult[HttpServer] =>
         assertTrue(ar.succeeded())
-        vertx.newHttpClient.setPort(port).connectWebsocket("/") { w: WebSocket =>
+        sVertx.createHttpClient.setPort(port).connectWebsocket("/") { w: WebSocket =>
           w.dataHandler { b: Buffer =>
             assertEquals(html.toString(), b.toString)
             testComplete()


### PR DESCRIPTION
I've changed all new\* methods to create*, just like the Java API. The tests need a Scala vertx which TestVerticle doesn't provide - it gives a Java vertx - hence these "sVertx" in some of the classes.

In future versions the TestVerticle should be replaced by a Scala version.
