### PR TITLE
Rename module zip to properly use vert.x module naming scheme.

### DIFF
--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -105,7 +105,7 @@ task modZip( type: Zip, dependsOn: 'pullInDeps', description: 'Package the modul
   group = 'vert.x'
   description = "Assembles a vert.x module"
   destinationDir = project.file('build/libs')
-  archiveName = "${modname}-${version}" + ".zip"
+  archiveName = "${modname}-${version}" + "-mod.zip"
   from copyMod
 }
 


### PR DESCRIPTION
Rename module zip  as requested by @purplefox.

@galderz This should be backported to 0.1.0 branch so we could submit it in the module registry.
