### PR TITLE
Enable incremental compilation.

### DIFF
--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -177,3 +177,8 @@ plugins.withType(IdeaPlugin) {
     }
   }
 }
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.useAnt = false
+}
+


### PR DESCRIPTION
Enabled incremental compilation. There is an overhead on the first build but on the succeeding builds it should be faster.
