### PR TITLE
remove Json.apply() methods and simplify Json.arr() usage

### DIFF
--- a/src/main/scala/org/vertx/scala/core/json/Json.scala
+++ b/src/main/scala/org/vertx/scala/core/json/Json.scala
@@ -71,22 +71,6 @@ object JsonElemOps {
 object Json {
 
   /**
-   * Constructs a JsonObject from a fieldName -> value pairs.
-   *
-   * @param fields The fieldName -> value pairs
-   * @return A JsonObject containing the name -> value pairs.
-   */
-  def apply(fields: (String, Any)*): JsonObject = obj(fields: _*)
-
-  /**
-   * Creates a JsonArray from a sequence of values.
-   *
-   * @param elements The elements to put into the JsonArray.
-   * @return A JsonArray containing the provided elements.
-   */
-  def apply(elements: Seq[Any]): JsonArray = arr(elements)
-
-  /**
    * Creates a JsonArray from an encoded JSON string.
    *
    * @param json The JSON string.
@@ -133,7 +117,7 @@ object Json {
    * @param elements The elements to put into the JsonArray.
    * @return A JsonArray containing the provided elements.
    */
-  def arr(fields: Seq[Any]): JsonArray = {
+  def arr(fields: Any*): JsonArray = {
     val a = new JsonArray()
     fields.foreach(f => addToArray(a, f))
     a

--- a/src/test/scala/org/vertx/scala/tests/core/json/JsonTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/core/json/JsonTest.scala
@@ -21,6 +21,7 @@ import org.vertx.scala.core.json._
 
 /**
  * @author Edgar Chan
+ * @author <a href="http://www.campudus.com/">Joern Bernhardt</a>
  */
 class JsonTest {
 
@@ -34,15 +35,13 @@ class JsonTest {
         "foo" -> "foo text",
         "bar" -> 3.45d,
         "baz" -> false,
-        "myInt" -> Integer.MAX_VALUE
-      )
+        "myInt" -> Integer.MAX_VALUE)
 
     assertEquals("foo text", obj.getString("foo"))
     assertEquals(3.45d, obj.getValue[Double]("bar"), 1e-15)
     assertEquals(false, obj.getBoolean("baz"))
     assertEquals(Integer.MAX_VALUE, obj.getInteger("myInt"))
     assertEquals(enc, obj.encode())
-
 
   }
 
@@ -55,7 +54,7 @@ class JsonTest {
     val scalaMapFields: scala.collection.Map[String, AnyRef] = wrapped.asMap
 
     //Get the original object
-    val obj2:JsonObject =  wrapped
+    val obj2: JsonObject = wrapped
 
     assertEquals("foo text", scalaMapFields("foo"))
     assertEquals(true, obj2.getBoolean("optional"))
@@ -66,85 +65,45 @@ class JsonTest {
   def jsonArrayTest() {
 
     val enc = """["f",3,"b",7,35.4,true]"""
-    val array = Json.arr(List("f", 3, "b", 7, 35.4f, true))
+    val array = Json.arr("f", 3, "b", 7, 35.4f, true)
 
     assertEquals(6, array.size())
     assertEquals(enc, array.encode())
   }
 
-
   @Test
-  def customObjTest(){
+  def customObjTest() {
     import java.util.Date
 
-    case class Custom(date:Date, other:Boolean)
+    case class Custom(date: Date, other: Boolean)
     val info = Custom(new Date(), false)
-    val obj1 =  Json.obj("custom" -> info)
+    val obj1 = Json.obj("custom" -> info)
 
     assertEquals(info, obj1.getValue[Custom]("custom"))
   }
 
   @Test
-  def nestedObjectsTest(){
+  def nestedObjectsTest() {
     val obj =
       Json.obj(
-        "webappconf"  -> Json.obj(
-             "port"   -> 8080,
-             "ssl"    -> false,
-             "bridge" -> true,
-             "inbound_permitted" -> Json.arr(
-                 Seq(Json.obj(
-                   "address" -> "acme.bar",
-                   "match"   -> Json.obj(
-                       "action" -> "foo"
-                    )),
-                   Json.obj(
-                    "address" -> "acme.baz",
-                    "match"   -> Json.obj(
-                        "action" -> "index"
-                     ))
-                 )
-             ),
-             "outbound_permitted"  -> Json.arr(
-                 Seq(new JsonObject())
-             )
-         )
-      )
+        "webappconf" -> Json.obj(
+          "port" -> 8080,
+          "ssl" -> false,
+          "bridge" -> true,
+          "inbound_permitted" -> Json.arr(
+            Json.obj(
+              "address" -> "acme.bar",
+              "match" -> Json.obj(
+                "action" -> "foo")),
+            Json.obj(
+              "address" -> "acme.baz",
+              "match" -> Json.obj(
+                "action" -> "index"))),
+          "outbound_permitted" -> Json.arr(
+            new JsonObject())))
 
     assertEquals(jsonString, obj.encode())
   }
-
-
-  @Test
-  def nestedObjectsShorterVersionTest(){
-    val obj =
-      Json(
-        "webappconf"  -> Json(
-             "port"   -> 8080,
-             "ssl"    -> false,
-             "bridge" -> true,
-             "inbound_permitted" -> Json(
-                 Seq(Json(
-                   "address" -> "acme.bar",
-                   "match"   -> Json(
-                       "action" -> "foo"
-                    )),
-                   Json(
-                    "address" -> "acme.baz",
-                    "match"   -> Json(
-                        "action" -> "index"
-                     ))
-                 )
-             ),
-             "outbound_permitted" -> Json(
-                 Seq(new JsonObject())
-             )
-         )
-      )
-
-    assertEquals(jsonString, obj.encode())
-  }
-
 
   private def jsonString = {
     """


### PR DESCRIPTION
As discussed in the big PR, here is a version of `Json` without the apply methods and an `Any` argument list instead of a Seq[Any] parameter.
