### PR TITLE
Convert sequences automatically to JsonArrays

### DIFF
--- a/src/main/scala/org/vertx/scala/core/json/Json.scala
+++ b/src/main/scala/org/vertx/scala/core/json/Json.scala
@@ -107,7 +107,11 @@ object Json {
    */
   def obj(fields: (String, Any)*): JsonObject = {
     val o = new JsonObject()
-    fields.foreach(f => addToObject(o, f._1, f._2))
+    fields.foreach {
+      case (key, l: Array[_]) => addToObject(o, key, listToJsArr(l))
+      case (key, l: Seq[_]) => addToObject(o, key, listToJsArr(l))
+      case (key, value) => addToObject(o, key, value)
+    }
     o
   }
 
@@ -119,10 +123,15 @@ object Json {
    */
   def arr(fields: Any*): JsonArray = {
     val a = new JsonArray()
-    fields.foreach(f => addToArray(a, f))
+    fields.foreach {
+      case array: Array[_] => addToArray(a, listToJsArr(array))
+      case seq: Seq[_] => addToArray(a, listToJsArr(seq))
+      case f => addToArray(a, f)
+    }
     a
   }
 
+  private def listToJsArr(a: Seq[_]) = Json.arr(a: _*)
   private def addToArray[T: JsonElemOps](a: JsonArray, fieldValue: T) = {
     implicitly[JsonElemOps[T]].addToArr(a, fieldValue)
   }

--- a/src/test/scala/org/vertx/scala/tests/core/json/JsonTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/core/json/JsonTest.scala
@@ -90,6 +90,8 @@ class JsonTest {
           "port" -> 8080,
           "ssl" -> false,
           "bridge" -> true,
+          "some_nested" -> Json.arr(1, 2, Json.obj("next" -> Json.arr(3, 4))),
+          "some_list" -> Json.arr(1, 2, Json.arr(3, 4)),
           "inbound_permitted" -> Json.arr(
             Json.obj(
               "address" -> "acme.bar",
@@ -105,6 +107,78 @@ class JsonTest {
     assertEquals(jsonString, obj.encode())
   }
 
+  @Test
+  def nestedObjectsWithListsTest() {
+    val obj =
+      Json.obj(
+        "webappconf" -> Json.obj(
+          "port" -> 8080,
+          "ssl" -> false,
+          "bridge" -> true,
+          "some_nested" -> List(1, 2, Json.obj("next" -> List(3, 4))),
+          "some_list" -> List(1, 2, List(3, 4)),
+          "inbound_permitted" -> List(
+            Json.obj(
+              "address" -> "acme.bar",
+              "match" -> Json.obj(
+                "action" -> "foo")),
+            Json.obj(
+              "address" -> "acme.baz",
+              "match" -> Json.obj(
+                "action" -> "index"))),
+          "outbound_permitted" -> List(new JsonObject())))
+
+    assertEquals(jsonString, obj.encode())
+  }
+
+  @Test
+  def nestedObjectsWithArraysTest() {
+    val obj =
+      Json.obj(
+        "webappconf" -> Json.obj(
+          "port" -> 8080,
+          "ssl" -> false,
+          "bridge" -> true,
+          "some_nested" -> Array(1, 2, Json.obj("next" -> Array(3, 4))),
+          "some_list" -> Array(1, 2, Array(3, 4)),
+          "inbound_permitted" -> Array(
+            Json.obj(
+              "address" -> "acme.bar",
+              "match" -> Json.obj(
+                "action" -> "foo")),
+            Json.obj(
+              "address" -> "acme.baz",
+              "match" -> Json.obj(
+                "action" -> "index"))),
+          "outbound_permitted" -> Array(new JsonObject())))
+
+    assertEquals(jsonString, obj.encode())
+  }
+
+  @Test
+  def mixedNestedObjectsTest() {
+    val obj =
+      Json.obj(
+        "webappconf" -> Json.obj(
+          "port" -> 8080,
+          "ssl" -> false,
+          "bridge" -> true,
+          "some_nested" -> Vector(1, 2, Json.obj("next" -> List(3, 4))),
+          "some_list" -> Json.arr(1, 2, Vector(3, 4)),
+          "inbound_permitted" -> List(
+            Json.obj(
+              "address" -> "acme.bar",
+              "match" -> Json.obj(
+                "action" -> "foo")),
+            Json.obj(
+              "address" -> "acme.baz",
+              "match" -> Json.obj(
+                "action" -> "index"))),
+          "outbound_permitted" -> Array(new JsonObject())))
+
+    assertEquals(jsonString, obj.encode())
+  }
+
   private def jsonString = {
     """
       |{
@@ -112,6 +186,8 @@ class JsonTest {
       |          "port": 8080,
       |          "ssl": false,
       |          "bridge": true,
+      |          "some_nested": [1, 2, { "next": [3, 4] }],
+      |          "some_list": [1, 2, [3, 4]],
       |          "inbound_permitted": [
       |            {
       |              "address" : "acme.bar",


### PR DESCRIPTION
If I put in an `Array` or a `List`/`Vector`/`Seq`, these now get automatically converted to `JsonArray`.

So doing a `Json.obj("some_list" -> List(1, 2, List(3, 4)))` becomes `{"some_list":[1,2,[3,4]]}`.
