### PR TITLE
Use latest snapshot version for tests.

### DIFF
--- a/src/test/resources/langs.properties
+++ b/src/test/resources/langs.properties
@@ -1,2 +1,2 @@
-scala=io.vertx~lang-scala~0.2.0-SNAPSHOT:org.vertx.scala.platform.impl.ScalaVerticleFactory
+scala=io.vertx~lang-scala~0.3.0-SNAPSHOT:org.vertx.scala.platform.impl.ScalaVerticleFactory
 .scala=scala


### PR DESCRIPTION
It was using 0.2.0-SNAPSHOT version of mod-lang-scala before, since we
bumped the version to 0.3.0-SNAPSHOT the tests should be run against it.
