### PR TITLE
Added ScalaBusMod for a nicer interface for eventbus modules

### DIFF
--- a/src/main/scala/org/vertx/scala/core/VertxAccess.scala
+++ b/src/main/scala/org/vertx/scala/core/VertxAccess.scala
@@ -1,0 +1,15 @@
+package org.vertx.scala.core
+
+import org.vertx.scala.core.logging.Logger
+import org.vertx.scala.platform.Container
+
+/**
+ * Classes implementing this trait provide direct access to `Vertx`, `Container` and `Logger`. Be
+ * cautious when using this trait: Do not use the provided `vertx`, `container` and `logger` at
+ * construction of the object, otherwise they might not be initialized yet.
+ */
+trait VertxAccess {
+  val vertx: Vertx
+  val container: Container
+  val logger: Logger
+}

--- a/src/main/scala/org/vertx/scala/mods/BusModException.scala
+++ b/src/main/scala/org/vertx/scala/mods/BusModException.scala
@@ -1,0 +1,3 @@
+package org.vertx.scala.mods
+
+case class BusModException(message: String = null, cause: Throwable = null, id: String = "MODULE_EXCEPTION") extends Exception(message, cause)

--- a/src/main/scala/org/vertx/scala/mods/ScalaBusMod.scala
+++ b/src/main/scala/org/vertx/scala/mods/ScalaBusMod.scala
@@ -1,0 +1,76 @@
+package org.vertx.scala.mods
+
+import scala.concurrent.Future
+import org.vertx.scala.core.VertxExecutionContext
+import org.vertx.scala.core.eventbus.{ JsonObjectData, Message }
+import org.vertx.scala.core.json.{ Json, JsonObject }
+import org.vertx.scala.mods.replies._
+import org.vertx.scala.core.VertxAccess
+
+/**
+ * Extend this trait to get an easy to use interface for your EventBus module. It relies on the
+ * sender sending JSON requests with an `{"action":"<something>"}`. It will reply with either a
+ * `{"status":"ok"}` JSON object or an `{"status":"error", "error":"<ERROR_CODE>",
+ * "message":"<detailed message of error>"}`. You can provide extra fields in your reply, by adding
+ * a JsonObject to your reply (`Ok` or `Error`). If you need to do something asynchronously while
+ * processing the message, use `AsyncReply`. You just need to map the `Future` to one of the `Ok` or
+ * `Error` replies. Exceptions that you forget to catch will always yield a "MODULE_EXCEPTION" error
+ * code.
+ */
+trait ScalaBusMod extends (Message[JsonObject] => Unit) with VertxExecutionContext with VertxAccess {
+
+  private val noActionMatch: BusModReply = Error("No matching action.", "INVALID_ACTION")
+  private val noAction: BusModReply = Error("No action received.", "MISSING_ACTION")
+
+  override final def apply(msg: Message[JsonObject]) = {
+    val reply: BusModReply = Option(msg.body.getString("action")) match {
+      case Some(action) =>
+        (try {
+          receive(msg).applyOrElse(action, { _: String => noActionMatch })
+        } catch {
+          case ex: Throwable =>
+            logger.warn("Uncaught Exception for request " + msg.body.encode(), ex)
+            Error("Module threw error: " + ex.getMessage(),
+              "MODULE_EXCEPTION",
+              Json.obj("exception" -> ex.getStackTrace().mkString("\n")))
+        })
+      case None => noAction
+    }
+
+    sendReply(msg, reply)
+  }
+
+  /**
+   * Sends a reply back to the sender. This handles AsyncReplies, so Futures or errors in Futures
+   * will get caught and reply with their reply type when they are done (or an `Error` in case of an
+   * uncaught exception/failed `Future`).
+   *
+   * @param msg The message to reply to.
+   * @param reply The BusModReply to send.
+   */
+  private def sendReply(msg: Message[_], reply: BusModReply): Unit = reply match {
+    case AsyncReply(future) => future.map(x => sendReply(msg, x)).recover {
+      case BusModException(message, null, id) => sendFinalReply(msg, Error(message, id))
+      case BusModException(message, cause, id) =>
+        sendFinalReply(msg,
+          Error(message, id, Json.obj("exception" -> cause.getStackTrace().mkString("\n"))))
+      case ex =>
+        sendFinalReply(msg,
+          Error(ex.getMessage(), "MODULE_EXCEPTION", Json.obj("exception" -> ex.getStackTrace().mkString("\n"))))
+    }
+    case syncReply: SyncReply => sendFinalReply(msg, syncReply)
+  }
+
+  private def sendFinalReply(msg: Message[_], reply: SyncReply): Unit = msg.reply(reply.toJson)
+
+  /**
+   * Override this method to handle a message received via the eventbus. This function reads the
+   * `action` parameter out of the message and checks if the returned `PartialFunction` is defined
+   * on it. With the returned `BusModReply`, you can easily tell whether the message resulted in an
+   * error or everything went well by replying `Ok`.
+   *
+   * @param message The message that was received via the eventbus.
+   * @return A partial function consisting of an "action" -> BusModReply.
+   */
+  def receive(message: Message[JsonObject]): PartialFunction[String, BusModReply]
+}

--- a/src/main/scala/org/vertx/scala/mods/UnknownActionException.scala
+++ b/src/main/scala/org/vertx/scala/mods/UnknownActionException.scala
@@ -1,0 +1,3 @@
+package org.vertx.scala.mods
+
+class UnknownActionException(msg: String = null, cause: Throwable = null) extends BusModException(msg, cause, "UNKNOWN_ACTION")

--- a/src/main/scala/org/vertx/scala/mods/replies/busmodreplies.scala
+++ b/src/main/scala/org/vertx/scala/mods/replies/busmodreplies.scala
@@ -1,0 +1,19 @@
+package org.vertx.scala.mods.replies
+
+import org.vertx.scala.core.json._
+import scala.concurrent.Future
+
+sealed trait BusModReply
+
+case class AsyncReply(replyWhenDone: Future[BusModReply]) extends BusModReply
+
+sealed trait SyncReply extends BusModReply {
+  def toJson: JsonObject
+}
+case class Ok(x: JsonObject = Json.obj()) extends SyncReply {
+  def toJson = x.putString("status", "ok")
+}
+
+case class Error(message: String, id: String = "MODULE_EXCEPTION", obj: JsonObject = Json.obj()) extends SyncReply {
+  def toJson = Json.obj("status" -> "error", "message" -> message, "error" -> id).mergeIn(obj)
+}

--- a/src/main/scala/org/vertx/scala/platform/Verticle.scala
+++ b/src/main/scala/org/vertx/scala/platform/Verticle.scala
@@ -20,6 +20,7 @@ import scala.concurrent.Promise
 import org.vertx.scala.core.{ Vertx, VertxExecutionContext }
 import scala.concurrent.Future
 import org.vertx.scala.core.logging.Logger
+import org.vertx.scala.core.VertxAccess
 
 /**
  * A verticle is the unit of execution in the Vert.x platform<p>
@@ -30,7 +31,7 @@ import org.vertx.scala.core.logging.Logger
  * @author swilliams
  * @author <a href="http://www.campudus.com/">Joern Bernhardt</a>
  */
-trait Verticle extends VertxExecutionContext {
+trait Verticle extends VertxExecutionContext with VertxAccess {
 
   private var _vertx: Vertx = null
   private var _container: Container = null

--- a/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
@@ -1,0 +1,108 @@
+package org.vertx.scala.tests.mods
+
+import org.vertx.scala.testtools.TestVerticle
+import scala.concurrent.Promise
+import scala.concurrent.Future
+import org.vertx.scala.core.json._
+import org.vertx.scala.core.FunctionConverters._
+import scala.util.Try
+import scala.util.Success
+import scala.util.Failure
+import org.junit.Test
+import org.vertx.scala.core.eventbus.Message
+import org.vertx.testtools.VertxAssert._
+
+class ScalaBusModTest extends TestVerticle {
+  override def asyncBefore(): Future[Unit] = {
+    val p = Promise[Unit]
+    container.deployVerticle("scala:org.vertx.scala.tests.mods.TestBusMod", Json.obj(), 1, {
+      case Success(deploymentId) => p.success()
+      case Failure(ex) => p.failure(ex)
+    }: Try[String] => Unit)
+    p.future
+  }
+
+  val address = "test-bus-mod"
+
+  @Test
+  def syncHello(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "sync-hello"), { msg: Message[JsonObject] =>
+      assertEquals("ok", msg.body.getString("status"))
+      assertEquals("sync-hello-result", msg.body.getString("result"))
+      testComplete()
+    })
+  }
+
+  @Test
+  def syncError(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "sync-error"), { msg: Message[JsonObject] =>
+      assertEquals("Should receive an error status", "error", msg.body.getString("status"))
+      assertEquals("Should receive a MODULE_EXCEPTION", "MODULE_EXCEPTION", msg.body.getString("error"))
+      assertNotNull("Should receive an exception", msg.body.getString("exception"))
+      testComplete()
+    })
+  }
+
+  @Test
+  def syncEcho(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "sync-echo", "echo" -> "bla"), { msg: Message[JsonObject] =>
+      assertEquals("ok", msg.body.getString("status"))
+      assertEquals("bla", msg.body.getString("echo"))
+      testComplete()
+    })
+  }
+
+  @Test
+  def syncEchoError(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "sync-echo"), { msg: Message[JsonObject] =>
+      assertEquals("error", msg.body.getString("status"))
+      assertEquals("NO_ECHO_GIVEN", msg.body.getString("error"))
+      testComplete()
+    })
+  }
+
+  @Test
+  def asyncHello(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "async-hello"), { msg: Message[JsonObject] =>
+      assertEquals("ok", msg.body.getString("status"))
+      assertEquals("async-hello-result", msg.body.getString("result"))
+      testComplete()
+    })
+  }
+
+  @Test
+  def asyncErrorUncaught(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "async-error-1"), { msg: Message[JsonObject] =>
+      assertEquals("error", msg.body.getString("status"))
+      assertEquals("MODULE_EXCEPTION", msg.body.getString("error"))
+      testComplete()
+    })
+  }
+
+  @Test
+  def asyncErrorUncaughtCascade(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "async-cascade-uncaught"), { msg: Message[JsonObject] =>
+      assertEquals("error", msg.body.getString("status"))
+      assertEquals("MODULE_EXCEPTION", msg.body.getString("error"))
+      testComplete()
+    })
+  }
+
+  @Test
+  def asyncCascade(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "async-cascade"), { msg: Message[JsonObject] =>
+      assertEquals("ok", msg.body.getString("status"))
+      assertEquals("async-cascade-result", msg.body.getString("result"))
+      testComplete()
+    })
+  }
+
+  @Test
+  def asyncErrorCaught(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "async-error-2"), { msg: Message[JsonObject] =>
+      assertEquals("error", msg.body.getString("status"))
+      assertEquals("CAUGHT_EXCEPTION", msg.body.getString("error"))
+      testComplete()
+    })
+  }
+}

--- a/src/test/scala/org/vertx/scala/tests/mods/TestBusMod.scala
+++ b/src/test/scala/org/vertx/scala/tests/mods/TestBusMod.scala
@@ -1,0 +1,65 @@
+package org.vertx.scala.tests.mods
+
+import org.vertx.scala.platform.Verticle
+import org.vertx.scala.mods.ScalaBusMod
+import org.vertx.scala.core.eventbus.Message
+import org.vertx.scala.core.json._
+import org.vertx.scala.core.FunctionConverters._
+import org.vertx.scala.mods.replies._
+import scala.concurrent.Promise
+import scala.util.Try
+import scala.util.Success
+import scala.util.Failure
+import org.vertx.scala.mods.BusModException
+import scala.concurrent.Future
+
+class TestBusMod extends Verticle with ScalaBusMod {
+  override def start(promise: Promise[Unit]): Unit = {
+    vertx.eventBus.registerHandler("test-bus-mod", this, {
+      case Success(_) => promise.success()
+      case Failure(ex) => promise.failure(ex)
+    }: Try[Void] => Unit)
+  }
+
+  override def receive(msg: Message[JsonObject]) = {
+    case "sync-hello" => Ok(Json.obj("result" -> "sync-hello-result"))
+    case "sync-error" => throw new RuntimeException("sync-error-result")
+    case "sync-echo" =>
+      Option(msg.body.getString("echo")) match {
+        case Some(echo) => Ok(Json.obj("echo" -> echo))
+        case None => Error("No echo argument given!", "NO_ECHO_GIVEN")
+      }
+    case "async-hello" => AsyncReply {
+      val p = Promise[BusModReply]
+      vertx.setTimer(10, { timerId => p.success(Ok(Json.obj("result" -> "async-hello-result"))) })
+      p.future
+    }
+    case "async-cascade" => AsyncReply {
+      val p = Promise[BusModReply]
+      vertx.setTimer(10, { timerId =>
+        p.success(AsyncReply {
+          val p2 = Promise[BusModReply]
+          vertx.setTimer(10, { timerId2 =>
+            p2.success(Ok(Json.obj("result" -> "async-cascade-result")))
+          })
+          p2.future
+        })
+      })
+      p.future
+    }
+    case "async-cascade-uncaught" => AsyncReply {
+      val p = Promise[BusModReply]
+      vertx.setTimer(10, { timerId =>
+        p.failure(new RuntimeException("async-uncaught-exception"))
+      })
+      p.future
+    }
+    case "async-error-1" => AsyncReply {
+      throw new RuntimeException("uncaught-exception")
+    }
+    case "async-error-2" => AsyncReply {
+      Future.failed(new BusModException("caught-exception", id = "CAUGHT_EXCEPTION"))
+    }
+  }
+
+}


### PR DESCRIPTION
I'd like to delete ModuleBase as it's very java-like and propose this Scala version instead. I've already used something similar in [mod-mysql-postgresql](https://github.com/vert-x/mod-mysql-postgresql/blob/master/src/main/scala/io/vertx/busmod/ScalaBusMod.scala), but I found myself reusing it in almost every single module I've written with Scala. As the Java version provides ModuleBase, this Scala trait gives a lot of syntactic sugar if you use the "almost standard" way of providing an eventbus module.

It relies on the request having an "action" parameter. All other parameters depend on the action (and are thus implemented/handled through the module).

```
{
  "action" : "myaction",
  "some-parameter" : 123,
  "another-parameter" : true, ...
}
```

The module then always replies back with either an `Ok` message or an `Error` message. Here is an example for a successful processing:

```
{
  "status" : "ok",
  "some-result" : "whatever"
}
```

And an example for an error while processing:

```
{
  "status" : "error",
  "error" : "MY_ERROR_CODE",
  "message" : "Some detailed message about the error",
  "exception" : "An optional stacktrace of an Exception..."
}
```

See the [test module](https://github.com/Narigo/mod-lang-scala/blob/7b2f29996258614054184f0ba3965c28dec2db06/src/test/scala/org/vertx/scala/tests/mods/TestBusMod.scala) for a little example on how it is used.

There are some already defined error codes:
- `MODULE_EXCEPTION` - if the module throws an uncaught exception.
- `MISSING_ACTION` - if no action was provided by the sender.
- `INVALID_ACTION` - if the sender sent an action that did not get handled by the module (not in the `receive` method pattern match).
