### PR TITLE
|#83 Implement sendFile methods taking result handlers

### DIFF
--- a/src/main/scala/org/vertx/scala/core/http/HttpServerResponse.scala
+++ b/src/main/scala/org/vertx/scala/core/http/HttpServerResponse.scala
@@ -20,7 +20,7 @@ import org.vertx.java.core.http.{ HttpServerResponse => JHttpServerResponse }
 import org.vertx.scala.core.buffer._
 import org.vertx.scala.core.FunctionConverters._
 import org.vertx.scala.core.streams.WriteStream
-import org.vertx.scala.core.MultiMap
+import org.vertx.scala.core.{AsyncResult, MultiMap}
 import collection.JavaConverters._
 import org.vertx.scala.Self
 
@@ -167,11 +167,28 @@ final class HttpServerResponse private[scala] (val asJava: JHttpServerResponse) 
   def sendFile(filename: String): HttpServerResponse = wrap(asJava.sendFile(filename))
 
   /**
-   * If `chunked} is `true}, this response will use HTTP chunked encoding, and each call to write to the body
+   * If `chunked` is `true`, this response will use HTTP chunked encoding, and each call to write to the body
+   * Same as [[org.vertx.scala.core.http.HttpServerResponse.sendFile(String)]]
+   * but also takes a handler that will be called when the send has completed or
+   * a failure has occurred
+   */
+  def sendFile(filename: String, handler: AsyncResult[Void] => Unit): HttpServerResponse =
+    wrap(asJava.sendFile(filename, handler))
+
+  /**
+   * Same as [[org.vertx.scala.core.http.HttpServerResponse.sendFile(String, String)]]
+   * but also takes a handler that will be called when the send has completed or
+   * a failure has occurred
+   */
+  def sendFile(filename: String, notFoundFile: String, handler: AsyncResult[Void] => Unit): HttpServerResponse =
+    wrap(asJava.sendFile(filename, notFoundFile, handler))
+
+  /**
+   * If `chunked` is `true`, this response will use HTTP chunked encoding, and each call to write to the body
    * will correspond to a new HTTP chunk sent on the wire.<p>
-   * If chunked encoding is used the HTTP header `Transfer-Encoding} with a value of `Chunked} will be
+   * If chunked encoding is used the HTTP header `Transfer-Encoding` with a value of `Chunked` will be
    * automatically inserted in the response.<p>
-   * If `chunked} is `false}, this response will not use HTTP chunked encoding, and therefore if any data is written the
+   * If `chunked` is `false`, this response will not use HTTP chunked encoding, and therefore if any data is written the
    * body of the response, the total size of that data must be set in the `Content-Length` header <b>before</b> any
    * data is written to the response body.<p>
    * An HTTP chunked response is typically used when you do not know the total size of the request body up front.

--- a/src/test/scala/org/vertx/scala/tests/util/TestUtils.scala
+++ b/src/test/scala/org/vertx/scala/tests/util/TestUtils.scala
@@ -4,6 +4,7 @@ import org.vertx.scala.core.AsyncResult
 import org.vertx.testtools.VertxAssert._
 import org.vertx.scala.platform.Container
 import org.vertx.scala.core.buffer.Buffer
+import scala.annotation.tailrec
 
 /**
  * Port of some of the original TestUtils Helper methods.
@@ -45,6 +46,23 @@ object TestUtils {
       i += 1
     } while(i < length)
     line
+  }
+
+  def generateRandomUnicodeString(length: Int): String = {
+    val builder = new StringBuilder(length)
+    for (i <- 0 until length) {
+      @tailrec def generateChar(): Char = {
+        val c = (0xFFFF * Math.random()).toChar
+        // Skip illegal chars
+        if ((c >= 0xFFFE && c <= 0xFFFF) || (c >= 0xD800 && c <= 0xDFFF))
+          generateChar()
+        else
+          c
+      }
+
+      builder.append(generateChar())
+    }
+    builder.toString()
   }
 
 }


### PR DESCRIPTION
- Implement sendFile methods and add corresponding tests.
- Add missing tests for other sendFile methods.
- Compression tests were only enabling compression on the client, fixed tests so that when compression needs to be tested, both the server and the client are configured with compression.
