### PR TITLE
gh-87 Implemented EventBusBridgeHook and upgraded to 2.1-M5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ scalaVersion=2.10.2
 gradleVersion=1.6
 
 # The version of Vert.x
-vertxVersion=2.1M3
+vertxVersion=2.1M5
 
 # The version of Vert.x test tools
 toolsVersion=2.0.2-final

--- a/src/main/scala/org/vertx/scala/core/http/ServerWebSocket.scala
+++ b/src/main/scala/org/vertx/scala/core/http/ServerWebSocket.scala
@@ -34,6 +34,11 @@ final class ServerWebSocket private[scala] (val asJava: JServerWebSocket) extend
   override type J = JServerWebSocket
 
   /**
+   * The uri the websocket handshake occurred at
+   */
+  def uri(): String = asJava.uri()
+
+  /**
    * The path the websocket is attempting to connect at
    */
   def path(): String = asJava.path()

--- a/src/main/scala/org/vertx/scala/core/sockjs/EventBusBridgeHook.scala
+++ b/src/main/scala/org/vertx/scala/core/sockjs/EventBusBridgeHook.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.vertx.scala.core.sockjs
+
+import org.vertx.java.core.sockjs.{EventBusBridgeHook => JEventBusBridgeHook}
+import org.vertx.scala.core.json.JsonObject
+import org.vertx.scala.core._
+import org.vertx.scala.core.FunctionConverters._
+
+/**
+ * A hook that you can use to receive various events on the EventBusBridge.
+ *
+ * @author Galder Zamarreño
+ */
+final class EventBusBridgeHook private[scala] (val asJava: JEventBusBridgeHook) extends AnyVal {
+
+  /**
+   * Called when a new socket is created
+   * You can override this method to do things like check the origin header of a socket before
+   * accepting it
+   * @param sock The socket
+   * @return true to accept the socket, false to reject it
+   */
+  def handleSocketCreated(sock: SockJSSocket): Boolean =
+    asJava.handleSocketCreated(sock.asJava)
+
+  /**
+   * The socket has been closed
+   * @param sock The socket
+   */
+  def handleSocketClosed(sock: SockJSSocket): Unit =
+    asJava.handleSocketClosed(sock.asJava)
+
+  /**
+   * Client is sending or publishing on the socket
+   * @param sock The sock
+   * @param send if true it's a send else it's a publish
+   * @param msg The message
+   * @param address The address the message is being sent/published to
+   * @return true To allow the send/publish to occur, false otherwise
+   */
+  def handleSendOrPub(sock: SockJSSocket, send: Boolean, msg: JsonObject, address: String): Boolean =
+    asJava.handleSendOrPub(sock.asJava, send, msg, address)
+
+  /**
+   * Called before client registers a handler
+   * @param sock The socket
+   * @param address The address
+   * @return true to let the registration occur, false otherwise
+   */
+  def handlePreRegister(sock: SockJSSocket, address: String): Boolean =
+    asJava.handlePreRegister(sock.asJava, address)
+
+  /**
+   * Called after client registers a handler
+   * @param sock The socket
+   * @param address The address
+   */
+  def handlePostRegister(sock: SockJSSocket, address: String): Unit =
+    asJava.handlePostRegister(sock.asJava, address)
+
+  /**
+   * Client is unregistering a handler
+   * @param sock The socket
+   * @param address The address
+   */
+  def handleUnregister(sock: SockJSSocket, address: String): Boolean =
+    asJava.handleUnregister(sock.asJava, address)
+
+  /**
+   * Called before authorisation - you can override authorisation here if you don't want the default
+   * @param message The auth message
+   * @param sessionID The session ID
+   * @param handler Handler - call this when authorisation is complete
+   * @return true if you wish to override authorisation
+   */
+  def handleAuthorise(message: JsonObject, sessionID: String, handler: AsyncResult[Boolean] => Unit): Boolean =
+    asJava.handleAuthorise(message, sessionID, asyncResultConverter((x: java.lang.Boolean) => x.booleanValue)(handler))
+
+}
+
+object EventBusBridgeHook {
+  def apply(internal: JEventBusBridgeHook) = new EventBusBridgeHook(internal)
+}

--- a/src/main/scala/org/vertx/scala/core/sockjs/SockJSServer.scala
+++ b/src/main/scala/org/vertx/scala/core/sockjs/SockJSServer.scala
@@ -21,7 +21,6 @@ import org.vertx.java.core.json.JsonObject
 import org.vertx.java.core.sockjs.{ SockJSServer => JSockJSServer }
 import org.vertx.scala.Self
 import org.vertx.scala.core.FunctionConverters._
-import org.vertx.java.core.sockjs.EventBusBridgeHook
 
 /**
  * This is an implementation of the server side part of <a href="https://github.com/sockjs">SockJS</a>.<p>
@@ -117,7 +116,8 @@ final class SockJSServer private[scala] (val asJava: JSockJSServer) extends Self
    * Set a EventBusBridgeHook on the SockJS server
    * @param hook The hook
    */
-  def setHook(hook: EventBusBridgeHook): SockJSServer = wrap(asJava.setHook(hook))
+  def setHook(hook: EventBusBridgeHook): SockJSServer = wrap(asJava.setHook(hook.asJava))
+
 }
 
 /** Factory for [[org.vertx.scala.core.sockjs.SockJSServer]] instances. */

--- a/src/main/scala/org/vertx/scala/core/sockjs/SockJSSocket.scala
+++ b/src/main/scala/org/vertx/scala/core/sockjs/SockJSSocket.scala
@@ -18,8 +18,10 @@ package org.vertx.scala.core.sockjs
 
 import org.vertx.java.core.sockjs.{ SockJSSocket => JSockJSSocket }
 import org.vertx.scala.core.streams.{WriteStream, ReadStream}
+import org.vertx.scala.core.http._
 import org.vertx.scala.Self
 import java.net.InetSocketAddress
+import scala.collection.mutable
 
 /**
  * You interact with SockJS clients through instances of SockJS socket.
@@ -61,6 +63,17 @@ final class SockJSSocket private[scala] (val asJava: JSockJSSocket) extends Self
    * Return the local address for this socket
    */
   def localAddress(): InetSocketAddress = asJava.localAddress()
+
+  /**
+   * Return the headers corresponding to the last request for this socket or the websocket handshake
+   * Any cookie headers will be removed for security reasons
+   */
+  def headers: mutable.MultiMap[String, String] = multiMapToScalaMultiMap(asJava.headers())
+
+  /**
+   * Return the URI corresponding to the last request for this socket or the websocket handshake
+   */
+  def uri: String = asJava.uri()
 
 }
 

--- a/src/test/scala/org/vertx/scala/tests/core/json/JsonTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/core/json/JsonTest.scala
@@ -72,6 +72,17 @@ class JsonTest {
     assertEquals(enc, array.encode())
   }
 
+  @Test @Ignore("https://groups.google.com/forum/?fromgroups=#!topic/vertx/TJ2B3D_1zrA and https://groups.google.com/forum/?fromgroups=#!topic/vertx/lOmoB96w8hc")
+  def customObjTest() {
+    import java.util.Date
+
+    case class Custom(date: Date, other: Boolean)
+    val info = Custom(new Date(), false)
+    val obj1 = Json.obj("custom" -> info)
+
+    assertEquals(info, obj1.getValue[Custom]("custom"))
+  }
+
   @Test
   def nestedObjectsTest() {
     val obj =


### PR DESCRIPTION
- Disabled a test that is currently failing since JsonObjects cannot store references to objects any more. It should try serializing though. Actually, I have reinstated it, but being ignored.
- Added missing methods to SockJSSocket and ServerWebSocket
