### PR TITLE
gh-99 Execution context should use Verticle context to run runnable

### DIFF
--- a/src/main/scala/org/vertx/scala/mods/ScalaBusMod.scala
+++ b/src/main/scala/org/vertx/scala/mods/ScalaBusMod.scala
@@ -32,9 +32,11 @@ import org.vertx.scala.core.AsyncResult
  * `Error` replies. Exceptions that you forget to catch will always yield a "MODULE_EXCEPTION" error
  * code.
  */
-trait ScalaBusMod extends (Message[JsonObject] => Unit) with VertxExecutionContext with VertxAccess {
+trait ScalaBusMod extends (Message[JsonObject] => Unit) with VertxAccess {
 
   import ScalaBusMod._
+
+  implicit val executionContext = VertxExecutionContext.fromVertxAccess(this)
 
   private val noActionMatch: BusModReply = Error("No matching action.", "INVALID_ACTION")
   private val noAction: BusModReply = Error("No action received.", "MISSING_ACTION")

--- a/src/main/scala/org/vertx/scala/platform/Verticle.scala
+++ b/src/main/scala/org/vertx/scala/platform/Verticle.scala
@@ -16,10 +16,10 @@
 
 package org.vertx.scala.platform
 
-import scala.concurrent.Promise
-import org.vertx.scala.core.{ Vertx, VertxExecutionContext }
-import org.vertx.scala.core.logging.Logger
+import org.vertx.scala.core.Vertx
 import org.vertx.scala.core.VertxAccess
+import org.vertx.scala.core.logging.Logger
+import scala.concurrent.Promise
 
 /**
  * A verticle is the unit of execution in the Vert.x platform<p>
@@ -30,7 +30,7 @@ import org.vertx.scala.core.VertxAccess
  * @author swilliams
  * @author <a href="http://www.campudus.com/">Joern Bernhardt</a>
  */
-trait Verticle extends VertxExecutionContext with VertxAccess {
+trait Verticle extends VertxAccess {
 
   private var _vertx: Vertx = _
   private var _container: Container = _

--- a/src/main/scala/org/vertx/scala/platform/impl/ScalaVerticle.scala
+++ b/src/main/scala/org/vertx/scala/platform/impl/ScalaVerticle.scala
@@ -15,17 +15,18 @@
  */
 
 package org.vertx.scala.platform.impl
+
+import org.vertx.java.core.Future
 import org.vertx.java.core.{ Vertx => JVertx }
 import org.vertx.java.platform.{ Container => JContainer }
 import org.vertx.java.platform.{ Verticle => JVerticle }
-import org.vertx.java.core.Future
 import org.vertx.scala.core.Vertx
-import org.vertx.scala.platform.Verticle
-import org.vertx.scala.platform.Container
-import scala.util.Success
-import scala.util.Failure
 import org.vertx.scala.core.VertxExecutionContext
+import org.vertx.scala.platform.Container
+import org.vertx.scala.platform.Verticle
 import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
 
 /**
  * @author swilliams
@@ -40,7 +41,9 @@ object ScalaVerticle {
   }
 }
 
-final private[platform] class ScalaVerticle(delegate: Verticle) extends JVerticle with VertxExecutionContext {
+final private[platform] class ScalaVerticle(delegate: Verticle) extends JVerticle {
+
+  implicit val executionContext = VertxExecutionContext.fromVertxAccess(delegate)
 
   override def setContainer(jcontainer: JContainer) = {
     delegate.setContainer(new Container(jcontainer))

--- a/src/test/scala/org/vertx/scala/tests/core/dns/DnsTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/core/dns/DnsTest.scala
@@ -28,6 +28,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.resolveA("vertx.io", { ar: AsyncResult[List[Inet4Address]] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: List[Inet4Address] = ar.result
 
@@ -48,6 +49,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.resolveAAAA("vertx.io", { ar: AsyncResult[List[Inet6Address]] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: List[Inet6Address] = ar.result
 
@@ -71,6 +73,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.resolveMX("vertx.io", { ar: AsyncResult[List[MxRecord]] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: List[MxRecord] = ar.result()
         val record: MxRecord = result(0)
@@ -93,6 +96,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.resolveTXT("vertx.io", { ar: AsyncResult[List[String]] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: List[String] = ar.result()
         assertTrue(!result.isEmpty)
@@ -113,6 +117,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.resolveNS("vertx.io", { ar: AsyncResult[List[String]] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: List[String] = ar.result()
         assertTrue(!result.isEmpty)
@@ -133,6 +138,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.resolveCNAME("vertx.io", { ar: AsyncResult[List[String]] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: List[String] = ar.result()
         val record: String = result(0)
@@ -155,6 +161,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.resolvePTR("10.0.0.1.in-addr.arpa", { ar: AsyncResult[String] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: String = ar.result()
         assertTrue(!result.isEmpty)
@@ -177,6 +184,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.resolveSRV("vertx.io", { ar: AsyncResult[List[SrvRecord]] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: List[SrvRecord] = ar.result()
         val record: SrvRecord = result(0)
@@ -201,6 +209,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.lookup4("vertx.io", { ar: AsyncResult[Inet4Address] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: InetAddress = ar.result()
         assertEquals(ip, result.getHostAddress())
@@ -219,6 +228,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.lookup6("vertx.io", { ar: AsyncResult[Inet6Address] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: Inet6Address = ar.result()
         (0 to IP6_BYTES.length - 1) map (i => assertEquals(IP6_BYTES(i),result.getAddress()(i)))
@@ -237,6 +247,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.lookup("vertx.io", { ar: AsyncResult[InetAddress] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: InetAddress = ar.result()
         assertEquals(ip, result.getHostAddress())
@@ -254,6 +265,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.lookup("gfegjegjf.sg1", { ar: AsyncResult[InetAddress] =>
+        assertThread()
         val cause: DnsException = ar.cause().asInstanceOf[DnsException]
         assertEquals(cause.code, DnsResponseCode.fromJava(JDnsResponseCode.NXDOMAIN))
         server.stop()
@@ -269,6 +281,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.reverseLookup("10.0.0.1", { ar: AsyncResult[InetAddress] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: InetAddress = ar.result()
         assertTrue(result.isInstanceOf[Inet4Address])
@@ -290,6 +303,7 @@ class DnsTest extends TestVerticle {
     val dns: DnsClient = prepareDns(server)
 
     dns.reverseLookup("::1", { ar: AsyncResult[InetAddress] =>
+      assertThread()
       if (ar.succeeded()) {
         val result: InetAddress = ar.result()
         assertTrue(result.isInstanceOf[Inet6Address])

--- a/src/test/scala/org/vertx/scala/tests/core/eventbus/EventBusBridgeTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/core/eventbus/EventBusBridgeTest.scala
@@ -33,9 +33,11 @@ class EventBusBridgeTest extends TestVerticle {
     sockJSServer.bridge(Json.obj("prefix" -> "/eventbus"), permitted, permitted)
 
     server.listen(8080, result => {
+      assertThread()
       def client = vertx.createHttpClient().setPort(8080)
       // We use rawwebsocket transport
       client.connectWebsocket("/eventbus/websocket", websocket => {
+        assertThread()
         // Register
         val msg = Json.obj("type" -> "register", "address" -> "someaddress")
         websocket.writeTextFrame(msg.encode())
@@ -45,6 +47,7 @@ class EventBusBridgeTest extends TestVerticle {
         websocket.writeTextFrame(msg2.encode())
 
         websocket.dataHandler { buffer =>
+            assertThread()
             val msg = buffer.toString()
             val received = Json.fromObjectString(msg)
             assert(received.getString("body").equals("hello world"))

--- a/src/test/scala/org/vertx/scala/tests/core/file/FileTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/core/file/FileTest.scala
@@ -182,6 +182,7 @@ class FileTest extends TestVerticle {
   } yield assertEquals("Hello-World", rf.toString()))
 
   private def resultInPromise[T](p: Promise[T]): AsyncResult[T] => Unit = { ar: AsyncResult[T] =>
+    assertThread()
     if (ar.succeeded()) {
       p.success(ar.result())
     } else {

--- a/src/test/scala/org/vertx/scala/tests/core/http/HttpTestForSimpleApi.scala
+++ b/src/test/scala/org/vertx/scala/tests/core/http/HttpTestForSimpleApi.scala
@@ -225,6 +225,7 @@ class HttpTestForSimpleApi extends TestVerticle {
       localServer.listen(testPort, { res =>
         if (res.succeeded()) {
           val client = vertx.createHttpClient().setPort(testPort).setTryUseCompression(compression)
+          assertThread()
           fn(client)
         } else {
           fail("listening did not succeed: " + res.cause().getMessage)

--- a/src/test/scala/org/vertx/scala/tests/lang/ScalaInterpreterTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/lang/ScalaInterpreterTest.scala
@@ -50,9 +50,10 @@ class ScalaInterpreterTest extends TestVerticle {
 
   private def assertHttpClientGetNow(expected: String) {
     val client = vertx.createHttpClient().setPort(8080)
-    client.getNow("/", {
-      h => h.bodyHandler {
-        data => {
+    client.getNow("/", { h =>
+        assertThread()
+        h.bodyHandler { data => {
+          assertThread()
           assertEquals(expected, data.toString())
           testComplete()
         }

--- a/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
@@ -29,6 +29,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def missingAction(): Unit = {
     vertx.eventBus.send(address, Json.obj("echo" -> "bla"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("error", msg.body.getString("status"))
       assertEquals("MISSING_ACTION", msg.body.getString("error"))
       assertNotNull("Should receive a message", msg.body.getString("message"))
@@ -39,6 +40,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def unknownAction(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "asdfgh", "echo" -> "bla"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("error", msg.body.getString("status"))
       assertEquals("INVALID_ACTION", msg.body.getString("error"))
       assertNotNull("Should receive a message", msg.body.getString("message"))
@@ -49,6 +51,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def syncHello(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "sync-hello"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("ok", msg.body.getString("status"))
       assertEquals("sync-hello-result", msg.body.getString("result"))
       testComplete()
@@ -58,6 +61,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def syncError(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "sync-error"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("Should receive an error status", "error", msg.body.getString("status"))
       assertEquals("Should receive a MODULE_EXCEPTION", "MODULE_EXCEPTION", msg.body.getString("error"))
       assertNotNull("Should receive an exception", msg.body.getString("exception"))
@@ -68,6 +72,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def syncEcho(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "sync-echo", "echo" -> "bla"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("ok", msg.body.getString("status"))
       assertEquals("bla", msg.body.getString("echo"))
       testComplete()
@@ -77,6 +82,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def syncEchoError(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "sync-echo"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("error", msg.body.getString("status"))
       assertEquals("NO_ECHO_GIVEN", msg.body.getString("error"))
       testComplete()
@@ -86,6 +92,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def asyncHello(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "async-hello"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("ok", msg.body.getString("status"))
       assertEquals("async-hello-result", msg.body.getString("result"))
       testComplete()
@@ -95,6 +102,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def asyncErrorUncaught(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "async-error-1"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("error", msg.body.getString("status"))
       assertEquals("MODULE_EXCEPTION", msg.body.getString("error"))
       testComplete()
@@ -104,6 +112,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def asyncErrorUncaughtCascade(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "async-cascade-uncaught"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("error", msg.body.getString("status"))
       assertEquals("MODULE_EXCEPTION", msg.body.getString("error"))
       testComplete()
@@ -113,6 +122,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def asyncCascade(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "async-cascade"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("ok", msg.body.getString("status"))
       assertEquals("async-cascade-result", msg.body.getString("result"))
       testComplete()
@@ -122,6 +132,7 @@ class ScalaBusModTest extends TestVerticle {
   @Test
   def asyncErrorCaught(): Unit = {
     vertx.eventBus.send(address, Json.obj("action" -> "async-error-2"), { msg: Message[JsonObject] =>
+      assertThread()
       assertEquals("error", msg.body.getString("status"))
       assertEquals("CAUGHT_EXCEPTION", msg.body.getString("error"))
       testComplete()
@@ -134,6 +145,7 @@ class ScalaBusModTest extends TestVerticle {
     val randomAddress = java.util.UUID.randomUUID().toString()
     val i = new AtomicInteger(2)
     vertx.eventBus.registerHandler(randomAddress, { msg: Message[JsonObject] =>
+      assertThread()
       val timeAtEnd = System.currentTimeMillis()
       assertEquals("bla", msg.body.getString("echo"))
       assertTrue("Should get a message here within 500 millis", timeAtStart >= (timeAtEnd - 500))
@@ -145,6 +157,7 @@ class ScalaBusModTest extends TestVerticle {
     vertx.eventBus.sendWithTimeout(address, Json.obj("action" -> "no-direct-reply",
       "address" -> randomAddress, "echo" -> "bla"),
       500L, { ar: AsyncResult[Message[JsonObject]] =>
+        assertThread()
         assertTrue("Should fail because of timeout", ar.failed())
         if (i.decrementAndGet() == 0) {
           testComplete()
@@ -159,6 +172,7 @@ class ScalaBusModTest extends TestVerticle {
       assertEquals("bla", msg.body.getString("echo"))
       msg.reply(Json.obj("action" -> "reply-notimeout-reply", "echo" -> "blubb"), {
         msg: Message[JsonObject] =>
+          assertThread()
           assertEquals("ok", msg.body.getString("status"))
           assertEquals("blubb", msg.body.getString("echo"))
           testComplete()
@@ -171,6 +185,7 @@ class ScalaBusModTest extends TestVerticle {
     val timeAtStart = System.currentTimeMillis()
     val randomAddress = java.util.UUID.randomUUID().toString()
     vertx.eventBus.registerHandler(randomAddress, { msg: Message[JsonObject] =>
+      assertThread()
       val timeAtEnd = System.currentTimeMillis()
       assertEquals("timeout", msg.body.getString("state"))
       assertTrue("Should get the timeout after 500 millis", timeAtStart <= (timeAtEnd - 500))
@@ -179,6 +194,7 @@ class ScalaBusModTest extends TestVerticle {
 
     vertx.eventBus.send(address, Json.obj("action" -> "reply-timeout", "address" -> randomAddress),
       { msg: Message[JsonObject] =>
+        assertThread()
         assertEquals("ok", msg.body.getString("status"))
         assertEquals("waitForTimeout", msg.body.getString("state"))
         // no reply to get BusMod into timeout

--- a/src/test/scala/org/vertx/scala/tests/plattform/impl/ScalaVerticleFactoryTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/plattform/impl/ScalaVerticleFactoryTest.scala
@@ -56,9 +56,10 @@ class ScalaVerticleFactoryTest extends TestVerticle {
 
   private def assertHttpClientGetNow(expected: String) {
     val client = vertx.createHttpClient().setPort(8080)
-    client.getNow("/", {
-      h => h.bodyHandler {
-        data => {
+    client.getNow("/", {h =>
+      assertThread()
+      h.bodyHandler { data => {
+          assertThread()
           assertEquals(expected, data.toString())
           testComplete()
         }


### PR DESCRIPTION
- Added thread assertions to tests to make sure callbacks are executed with the correct thread.
- VertxExecutionContext now extends VertxAccess in order to gain access to vertx and logger instances, and so be able to piggyback execution and logging calls.
