### PR TITLE
Kicked unnecessary assertion in ignoreReply test.

### DIFF
--- a/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
@@ -141,14 +141,11 @@ class ScalaBusModTest extends TestVerticle {
 
   @Test
   def ignoreReply(): Unit = {
-    val timeAtStart = System.currentTimeMillis()
     val randomAddress = java.util.UUID.randomUUID().toString()
     val i = new AtomicInteger(2)
     vertx.eventBus.registerHandler(randomAddress, { msg: Message[JsonObject] =>
       assertThread()
-      val timeAtEnd = System.currentTimeMillis()
       assertEquals("bla", msg.body.getString("echo"))
-      assertTrue("Should get a message here within 500 millis", timeAtStart >= (timeAtEnd - 500))
       if (i.decrementAndGet() == 0) {
         testComplete()
       }


### PR DESCRIPTION
This assertion might bite us, if the system is under heavy load, garbage collecting or similar.. We don't really need it here anyways.

Signed-off-by: Joern Bernhardt jb@campudus.com
