### PR TITLE
Ignore reply test question

### DIFF
--- a/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
@@ -147,7 +147,7 @@ class ScalaBusModTest extends TestVerticle {
       assertThread()
       assertEquals("bla", msg.body.getString("echo"))
       if (i.decrementAndGet() == 0) {
-        testComplete()
+        fail("The timeout handler should have been evaluated later.")
       }
     })
 
@@ -158,6 +158,8 @@ class ScalaBusModTest extends TestVerticle {
         assertTrue("Should fail because of timeout", ar.failed())
         if (i.decrementAndGet() == 0) {
           testComplete()
+        } else {
+          fail("The handler that doesn't send a reply should have been evaluated first.")
         }
       })
   }


### PR DESCRIPTION
@galderz I think this here won't necessarily work, but I just wanted to check whether my assumption is true. A reply handler can be called even after a timeout, I guess. Maybe a "registerLocalHandler" would work to make this assertion true in every case on a cloud server?

I don't think this here should be merged, but please have a look and tell me what you think.
