### PR TITLE
Added possibility to have Reply Handlers in Error cases

### DIFF
--- a/src/main/scala/org/vertx/scala/mods/replies/busmodreplies.scala
+++ b/src/main/scala/org/vertx/scala/mods/replies/busmodreplies.scala
@@ -38,8 +38,7 @@ case class Ok(x: JsonObject = Json.obj(), replyHandler: Option[ReplyReceiver] = 
   def toJson = x.putString("status", "ok")
 }
 
-case class Error(message: String, id: String = "MODULE_EXCEPTION", obj: JsonObject = Json.obj()) extends SyncReply {
-  val replyHandler = None
+case class Error(message: String, id: String = "MODULE_EXCEPTION", obj: JsonObject = Json.obj(), replyHandler: Option[ReplyReceiver] = None) extends SyncReply {
   def toJson = Json.obj("status" -> "error", "message" -> message, "error" -> id).mergeIn(obj)
 }
 

--- a/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
+++ b/src/test/scala/org/vertx/scala/tests/mods/ScalaBusModTest.scala
@@ -180,6 +180,20 @@ class ScalaBusModTest extends TestVerticle {
   }
 
   @Test
+  def replyBackAndForthWithError(): Unit = {
+    vertx.eventBus.send(address, Json.obj("action" -> "reply-error-ok", "echo" -> "bla"), { msg: Message[JsonObject] =>
+      assertEquals("error", msg.body.getString("status"))
+      msg.reply(Json.obj("action" -> "please", "echo" -> "bla"), {
+        msg: Message[JsonObject] =>
+          assertThread()
+          assertEquals("ok", msg.body.getString("status"))
+          assertEquals("bla", msg.body.getString("echo"))
+          testComplete()
+      })
+    })
+  }
+
+  @Test
   def replyTimeout(): Unit = {
     val timeAtStart = System.currentTimeMillis()
     val randomAddress = java.util.UUID.randomUUID().toString()

--- a/src/test/scala/org/vertx/scala/tests/mods/TestBusMod.scala
+++ b/src/test/scala/org/vertx/scala/tests/mods/TestBusMod.scala
@@ -74,6 +74,10 @@ class TestBusMod extends Verticle with ScalaBusMod {
       }, 500L, { () =>
         vertx.eventBus.send(clientAddress, Json.obj("state" -> "timeout"))
       })))
+    case "reply-error-ok" =>
+      Error("no.", replyHandler = Some(Receiver(msg => {
+        case "please" => Ok(Json.obj("echo" -> msg.body.getString("echo")))
+      })))
     case "no-direct-reply" =>
       val clientAddress = msg.body.getString("address")
       vertx.eventBus.send(clientAddress, Json.obj("echo" -> msg.body.getString("echo")))


### PR DESCRIPTION
ScalaBusMod did not allow handlers in case of an error. It should allow that as the module might want to send an error to inform the user and give the user to opportunity to fix it by providing another message as reply.

This is needed by mod-mysql-postgresql as well in order to roll back transactions more easily.
