### PR TITLE
gh-172 Fix module location for compilation on Windows (1.0.x)

### DIFF
--- a/src/main/scala/org/vertx/scala/platform/impl/ScalaVerticleFactory.scala
+++ b/src/main/scala/org/vertx/scala/platform/impl/ScalaVerticleFactory.scala
@@ -140,21 +140,21 @@ class ScalaVerticleFactory extends VerticleFactory {
       case None =>
         Failure(new IllegalStateException("Unable to resolve mod-lang-scala root location"))
       case Some(loc) =>
-        settings.bootclasspath.append(loc)
+        settings.bootclasspath.append(loc.getAbsolutePath)
         settings.usejavacp.value = true
         settings.verbose.value = ScalaInterpreter.isVerbose
         Success(settings)
     }
   }
 
-  private def getRootModuleLocation: Option[String] = {
-    AccessController.doPrivileged(new PrivilegedAction[Option[String]]() {
-      def run(): Option[String] = {
+  private def getRootModuleLocation: Option[File] = {
+    AccessController.doPrivileged(new PrivilegedAction[Option[File]]() {
+      def run(): Option[File] = {
         for {
           pd <- Option(classOf[ScalaVerticleFactory].getProtectionDomain)
           cs <- Option(pd.getCodeSource)
           loc <- Option(cs.getLocation)
-        } yield loc.toExternalForm
+        } yield new File(loc.toURI)
       }
     })
   }


### PR DESCRIPTION
- Using toExternalForm on URL produces a UNIX-style path which does not work fine on Windows machines. Instead, create a File with the URL's URI and get absolute path for it, which produces a platform dependant path.
