### PR TITLE
Added noMatch route matcher.

### DIFF
--- a/src/main/scala/org/vertx/scala/core/http/RouteMatcher.scala
+++ b/src/main/scala/org/vertx/scala/core/http/RouteMatcher.scala
@@ -66,6 +66,9 @@ class RouteMatcher private[scala] (val asJava: JRouteMatcher = new JRouteMatcher
   def headWithRegEx(regex: String, handler: HttpServerRequest => Unit): RouteMatcher =
     wrap(asJava.headWithRegEx(regex, wrapHandler(handler)))
 
+  def noMatch(handler: HttpServerRequest => Unit): RouteMatcher =
+    wrap(asJava.noMatch(wrapHandler(handler)))
+
   def options(uri: String, handler: HttpServerRequest => Unit): RouteMatcher =
     wrap(asJava.options(uri, wrapHandler(handler)))
 


### PR DESCRIPTION
noMatch was missing in Scala RouterMatcher wrapper for the Java RouteMatcher.  The documentation already contained instructions on how to use this command.

http://vertx.io/core_manual_scala.html#handling-requests-where-nothing-matches
