### PR TITLE
Proposed fix for issue 186

### DIFF
--- a/src/main/scala/org/vertx/scala/platform/impl/ScalaVerticleFactory.scala
+++ b/src/main/scala/org/vertx/scala/platform/impl/ScalaVerticleFactory.scala
@@ -51,8 +51,6 @@ class ScalaVerticleFactory extends VerticleFactory {
 
   private var loader: ClassLoader = null
 
-  //private var interpreter: ScalaInterpreter = null
-
   override def init(jvertx: JVertx, jcontainer: JContainer, aloader: ClassLoader): Unit = {
     this.loader = aloader
 
@@ -88,7 +86,6 @@ class ScalaVerticleFactory extends VerticleFactory {
   }
 
   def close(): Unit = {
-    //interpreter.close()
   }
 
   private def load(main: String): Try[Verticle] = {


### PR DESCRIPTION
Seems like access from different threads to the interpreter was causing the issue 186. Creating new interpreter for each load call works fine and fixes the issue. I've seen the same is done in the Java version of the VerticleFactory. Alternative could be to use ThreadLocal, I've tried that, it works fine, but I think doing what Java version does is probably better, as ThreadLocal would potentially hold up too many instances of the interpreter.
